### PR TITLE
Fixed parent key during unmarshalling, added safeGet methods

### DIFF
--- a/src/main/java/com/textquo/twist/ObjectStore.java
+++ b/src/main/java/com/textquo/twist/ObjectStore.java
@@ -53,6 +53,12 @@ public interface ObjectStore {
     public <T> T get(Class<T> clazz, Long id);
     public <T> T get(Class<T> clazz, String kind, String key);
     public <T> T get(Class<T> clazz, String kind, Long id);
+    
+    public <T> T safeGet(Class<T> clazz, Key key);
+    public <T> T safeGet(Class<T> clazz, String key);
+    public <T> T safeGet(Class<T> clazz, Long id);
+    public <T> T safeGet(Class<T> clazz, String kind, String key);
+    public <T> T safeGet(Class<T> clazz, String kind, Long id);
 
     public Iterable<Object> get(Iterable<Key> keys);
     public Object getInTransaction(Key key);

--- a/src/main/java/com/textquo/twist/common/ObjectNotFoundException.java
+++ b/src/main/java/com/textquo/twist/common/ObjectNotFoundException.java
@@ -1,7 +1,11 @@
 package com.textquo.twist.common;
 
+import com.google.appengine.api.datastore.EntityNotFoundException;
+
 public class ObjectNotFoundException extends TwistException {
-    public ObjectNotFoundException(String message){
-        super(message);
+	private static final long serialVersionUID = 6006726482159235720L;
+
+	public ObjectNotFoundException(String message, EntityNotFoundException e){
+        super(message, e);
     }
 }

--- a/src/main/java/com/textquo/twist/gae/GaeUnmarshaller.java
+++ b/src/main/java/com/textquo/twist/gae/GaeUnmarshaller.java
@@ -35,11 +35,11 @@ import com.textquo.twist.util.DateUtil;
 import com.textquo.twist.util.PrimitiveDefaults;
 import com.textquo.twist.validation.Validator;
 import com.textquo.twist.wrappers.PrimitiveWrapper;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.boon.Maps;
-
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -180,13 +180,22 @@ public class GaeUnmarshaller implements Unmarshaller {
         }
 
         AnnotatedField parentKeyField
-                = AnnotationUtil.getFieldWithAnnotation(GaeObjectStore.ancestor(), destination);
+                = AnnotationUtil.getFieldWithAnnotation(GaeObjectStore.parent(), destination);
         if(parentKeyField !=null){
             if(parentKeyField.getFieldType().equals(Key.class)){
                 parentKeyField.setFieldValue(entity.getParent());
             } else {
-                throw new RuntimeException("Only GAE Key can be used as @Ancestor");
+//                throw new RuntimeException("Only GAE Key can be used as @Ancestor");
             }
+        }
+        
+        AnnotatedField ancestorKeyField = AnnotationUtil.getFieldWithAnnotation(GaeObjectStore.ancestor(), destination);
+        if(ancestorKeyField !=null){
+        	if(ancestorKeyField.getFieldType().equals(Key.class)){
+        		ancestorKeyField.setFieldValue(getAncestor(entity));
+        	} else {
+                throw new RuntimeException("Only GAE Key can be used as @Ancestor");
+        	}
         }
 
         AnnotatedField idField
@@ -375,7 +384,15 @@ public class GaeUnmarshaller implements Unmarshaller {
         }
     }
 
-    /**
+    private Key getAncestor(Entity entity) {
+    	Key ancestor = entity.getKey();
+    	while (ancestor.getParent() != null) {
+    		ancestor = ancestor.getParent();
+    	}
+		return ancestor;
+	}
+
+	/**
      * Process <code>EmbeddedEntity</code> and inner <code>EmbeddedEntity</code>
      * of this entity.
      *


### PR DESCRIPTION
Working on luceneappengine twist migration I found an error during the unmarshalling of child entities that are built without parent ref. This commit will fix it but I'm not completely sure of the fix. Please double check it. This commit will fix one error in the tests on LAE-twist fork. If my commit is semantically correct we should build a  test to evidence this error in the twist framework just to avoid regression.
